### PR TITLE
don't resize mainmenu elements on hover

### DIFF
--- a/eqdkp_neon.css
+++ b/eqdkp_neon.css
@@ -1892,11 +1892,13 @@ ul.breamcrumb li.current  a{
 	margin-top: 0px;
 	text-shadow: 0px 0px 16px @templateMainColor3;
 	letter-spacing: -0.05em;
+	border-bottom: 1px solid transparent;
 }
 .sf-admin li , .mainmenu li{
 	background: @eqdkpMenuBackgroundColor;
 	border-right: 1px solid lighten(@templateMainColor8,10);
 	border-left: 1px solid desaturate(@templateMainColor8, 10);
+	line-height: 14px;
 }
 .sf-admin li li, .mainmenu li li {
 	background: darken(@eqdkpMenuItemBackgroundColor, 10);


### PR DESCRIPTION
_Ich schätze mal davon hast du gesprochen, dass wenn man ein 2 reihiges Menü hat aufgrund zuvieler Elemente. Und man dann über eines hoverd, alle nachfolgenden Elemente halb in der Luft hängen (es zerhackt ausschaut)..._

Dann sollte das `border-bottom: 1px solid transparent` auf einem a-Tag vollkommen ausreichen,
die `line-height` Angabe ist nur um das Homeknöpfchen auf gleicher Höhe zusetzen.

Macht bei mir so jedenfalls keine Spirenzien, allerdings habe ich das **nicht eingehend geprüft** bei Dropdown-tiefen und dem Adminmenü.
_Ist nur eben Quick & Dirty da das sf zeug eh rausfliegt, bald, irwann^^_
